### PR TITLE
Add /healthz endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,11 @@ type spec struct {
 	Config  string `envconfig:"DRONE_CONFIG_FILE" required:"true"`
 }
 
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
 func main() {
 	spec := new(spec)
 	err := envconfig.Process("", spec)
@@ -44,5 +49,7 @@ func main() {
 	logrus.Infof("server listening on address %s", spec.Address)
 
 	http.Handle("/", handler)
+	http.HandleFunc("/healthz", healthzHandler)
+
 	logrus.Fatal(http.ListenAndServe(spec.Address, nil))
 }


### PR DESCRIPTION
To aid in hosting this service in Kubernetes clusters or any other environments that needs healthchecks

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: drone-registry
spec:
  replicas: 1
  template:
    spec:
      automountServiceAccountToken: false
      containers:
      - name: registry
        # https://github.com/drone/drone-registry-plugin/pull/1
        image: imranismail/drone-registry-plugin:c72058b
        imagePullPolicy: IfNotPresent
        ports:
        - name: http
          containerPort: 3000
          protocol: TCP
        readinessProbe:
          httpGet:
            path: /healthz
            port: http
        envFrom:
        - configMapRef:
            name: drone-registry-cm
        env:
        - name: DRONE_SECRET
          valueFrom:
            secretKeyRef:
              name: drone-registry-secret
              key: DRONE_SECRET
        volumeMounts:
        - name: drone-registry-secret
          mountPath: /etc/drone/config.yaml
          subPath: config.yaml
          readOnly: true
      volumes:
      - name: drone-registry-secret
        secret:
          secretName: drone-registry-secret
```